### PR TITLE
Made v8 heap size ("old stack size") configurable and BGJSGLView fix

### DIFF
--- a/src/main/cpp/bgjs/BGJSV8Engine.cpp
+++ b/src/main/cpp/bgjs/BGJSV8Engine.cpp
@@ -954,6 +954,9 @@ void BGJSV8Engine::createContext() {
 		v8::V8::InitializePlatform(platform);
 		LOGD("Initialized platform");
 		v8::V8::Initialize();
+        std::string flags = "--max_old_space_size=";
+        flags = flags + std::to_string(_maxHeapSize);
+        v8::V8::SetFlagsFromString(flags.c_str(), flags.length());
 		LOGD("Initialized v8: %s", v8::V8::GetVersion());
 	}
 
@@ -1132,6 +1135,14 @@ float BGJSV8Engine::getDensity() const {
 
 void BGJSV8Engine::setDebug(bool debug) {
     _debug = debug;
+}
+
+/**
+ * Sets the maximum "old space" heap size in Megabytes we set for v8
+ * @param maxHeapSize max heap in mb
+ */
+void BGJSV8Engine::setMaxHeapSize(int maxHeapSize) {
+    _maxHeapSize = maxHeapSize;
 }
 
 char* BGJSV8Engine::loadFile(const char* path, unsigned int* length) const {

--- a/src/main/cpp/bgjs/BGJSV8Engine.h
+++ b/src/main/cpp/bgjs/BGJSV8Engine.h
@@ -104,6 +104,9 @@ public:
     void trace(const v8::FunctionCallbackInfo<v8::Value> &info);
 
     bool _debug;
+
+    void setMaxHeapSize(int maxHeapSize);
+
 private:
 	// called by JNIWrapper
 	static void initializeJNIBindings(JNIClassInfo *info, bool isReload);
@@ -142,6 +145,7 @@ private:
 	char *_lang;		// de
 	char *_tz;			// Europe/Berlin
 	char *_deviceClass; // "phone"/"tablet"
+	int _maxHeapSize;	// in MB
 
 	float _density;
 
@@ -165,6 +169,7 @@ private:
     v8::Local<v8::Function> makeRequireFunction(std::string pathName);
 
 	int _nextTimerId;
+
 };
 
 BGJS_JNI_LINK_DEF(BGJSV8Engine)

--- a/src/main/cpp/bgjs/ClientAndroid.cpp
+++ b/src/main/cpp/bgjs/ClientAndroid.cpp
@@ -54,7 +54,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)  {
 
 JNIEXPORT void JNICALL Java_ag_boersego_bgjs_ClientAndroid_initialize(
 		JNIEnv * env, jobject obj, jobject assetManager, jobject v8Engine, jstring locale, jstring lang,
-        jstring timezone, jfloat density, jstring deviceClass, jboolean debug) {
+        jstring timezone, jfloat density, jstring deviceClass, jboolean debug, jint maxHeapSize) {
 
 	auto ct = JNIV8Wrapper::wrapObject<BGJSV8Engine>(v8Engine);
 	ct->setAssetManager(assetManager);
@@ -66,11 +66,13 @@ JNIEXPORT void JNICALL Java_ag_boersego_bgjs_ClientAndroid_initialize(
 	ct->setLocale(localeStr, langStr, tzStr, deviceClassStr);
 	ct->setDensity(density);
 	ct->setDebug(debug);
+	ct->setMaxHeapSize(maxHeapSize);
 	env->ReleaseStringUTFChars(locale, localeStr);
 	env->ReleaseStringUTFChars(lang, langStr);
 	env->ReleaseStringUTFChars(timezone, tzStr);
     env->ReleaseStringUTFChars(deviceClass, deviceClassStr);
 	ct->createContext();
+
 	LOGD("BGJS context created");
 
 	ct->registerModule("canvas", BGJSGLModule::doRequire);

--- a/src/main/cpp/bgjs/jniext.h
+++ b/src/main/cpp/bgjs/jniext.h
@@ -12,7 +12,7 @@
 extern "C" {
 	// ClientAndroid
 	JNIEXPORT void JNICALL Java_ag_boersego_bgjs_ClientAndroid_initialize(
-			JNIEnv * env, jobject obj, jobject assetManager, jobject v8Engine, jstring locale, jstring lang, jstring timezone, float density, jstring deviceClass, jboolean debug);
+			JNIEnv * env, jobject obj, jobject assetManager, jobject v8Engine, jstring locale, jstring lang, jstring timezone, float density, jstring deviceClass, jboolean debug, jint maxHeapSizeInMb);
 	JNIEXPORT bool JNICALL Java_ag_boersego_bgjs_ClientAndroid_ajaxDone(
 		JNIEnv * env, jobject obj, jobject engine, jstring dataStr, jint responseCode,
 		jlong jsCbPtr, jlong thisPtr, jlong errorCb, jboolean success, jboolean processData);

--- a/src/main/cpp/bgjs/modules/BGJSGLModule.cpp
+++ b/src/main/cpp/bgjs/modules/BGJSGLModule.cpp
@@ -959,6 +959,8 @@ static void js_context_putImageData(const v8::FunctionCallbackInfo<v8::Value>& a
 void js_canvas_destruct(const v8::WeakCallbackInfo<void>& data) {
 	CanvasCallbackHolder* canvasHolder = (CanvasCallbackHolder*)data.GetParameter();
 
+    canvasHolder->persistent.Reset();
+
     delete canvasHolder->canvas;
     delete canvasHolder;
 }

--- a/src/main/java/ag/boersego/bgjs/ClientAndroid.java
+++ b/src/main/java/ag/boersego/bgjs/ClientAndroid.java
@@ -13,7 +13,7 @@ import android.content.res.AssetManager;
 public class ClientAndroid {
 	// BGJSV8Engine
 	public static native void timeoutCB(V8Engine engine, long jsCb, long thisObj, boolean cleanup, boolean runCallback);
-	public static native void initialize(AssetManager am, V8Engine engine, String locale, String lang, String timezone, float density, final String deviceClass, final boolean debug);
+	public static native void initialize(AssetManager am, V8Engine engine, String locale, String lang, String timezone, float density, final String deviceClass, final boolean debug, final int maxHeapSizeInMb);
 
 	// BGJSGLModule
     public static native int cssColorToInt(String color);

--- a/src/main/java/ag/boersego/bgjs/V8Engine.java
+++ b/src/main/java/ag/boersego/bgjs/V8Engine.java
@@ -305,7 +305,11 @@ public class V8Engine extends JNIObject implements Handler.Callback {
 			e.printStackTrace();
 		}
 		Log.d(TAG, "Initializing V8Engine");
-		ClientAndroid.initialize(assetManager, this, mLocale, mLang, mTimeZone, mDensity, mIsTablet ? "tablet" : "phone", BuildConfig.DEBUG);
+		final int maxHeapSizeForV8 = (int)(Runtime.getRuntime().maxMemory() / 1024 / 1024 / 3);
+		if (DEBUG) {
+			Log.d(TAG, "Max heap size for v8 is " + maxHeapSizeForV8 + " MB");
+		}
+		ClientAndroid.initialize(assetManager, this, mLocale, mLang, mTimeZone, mDensity, mIsTablet ? "tablet" : "phone", BuildConfig.DEBUG, maxHeapSizeForV8);
     }
 
     public native void registerModule(JNIV8Module module);

--- a/src/main/java/ag/boersego/bgjs/V8TextureView.java
+++ b/src/main/java/ag/boersego/bgjs/V8TextureView.java
@@ -327,7 +327,7 @@ abstract public class V8TextureView extends TextureView implements TextureView.S
 
         for (final JNIV8GenericObject touch : touchObjs) {
         	touch.dispose();
-		}
+        }
         touches.dispose();
         touchEventObj.dispose();
 	}

--- a/src/main/java/ag/boersego/bgjs/V8TextureView.java
+++ b/src/main/java/ag/boersego/bgjs/V8TextureView.java
@@ -324,6 +324,12 @@ abstract public class V8TextureView extends TextureView implements TextureView.S
         touchEventObj.setV8Field("touches", touches);
 
         mBGJSGLView.onEvent(touchEventObj);
+
+        for (final JNIV8GenericObject touch : touchObjs) {
+        	touch.dispose();
+		}
+        touches.dispose();
+        touchEventObj.dispose();
 	}
 
 	public void setClearColor(final int color) {


### PR DESCRIPTION
Heap size is set per default to 1/3 of app heap size.
Memory optimizations: dispose touch event objects eagerly.
Bug fix: run the whole rendering step in one v8::Locker.