### PR TITLE
always set 1min timeout in fetch

### DIFF
--- a/src/main/java/ag/boersego/bgjs/modules/BGJSModuleFetch.kt
+++ b/src/main/java/ag/boersego/bgjs/modules/BGJSModuleFetch.kt
@@ -65,8 +65,7 @@ class BGJSModuleFetch(val okHttpClient: OkHttpClient) : JNIV8Module("fetch") {
         var fetchResponse: BGJSModuleFetchResponse? = null
         val call = okHttpClient.newCall(httpRequest)
         val timeout = call.timeout()
-        val requestTimeOut = request.timeout.toLong() * 1000
-        timeout.timeout(requestTimeOut, TimeUnit.MILLISECONDS)
+        timeout.timeout(1, TimeUnit.MINUTES)
 
         val signal = request.signal
         var abortAndFinalize :JNIV8Function? = null

--- a/src/main/java/ag/boersego/bgjs/modules/BGJSModuleFetch.kt
+++ b/src/main/java/ag/boersego/bgjs/modules/BGJSModuleFetch.kt
@@ -65,7 +65,10 @@ class BGJSModuleFetch(val okHttpClient: OkHttpClient) : JNIV8Module("fetch") {
         var fetchResponse: BGJSModuleFetchResponse? = null
         val call = okHttpClient.newCall(httpRequest)
         val timeout = call.timeout()
-        timeout.timeout(1, TimeUnit.MINUTES)
+
+        val minute = 60000L
+        val requestTimeOut = request.timeout.toLong() * 1000
+        timeout.timeout(if (requestTimeOut > minute) requestTimeOut else minute, TimeUnit.MILLISECONDS)
 
         val signal = request.signal
         var abortAndFinalize :JNIV8Function? = null


### PR DESCRIPTION
Das Problem ist bei mir jetzt damit nicht mehr aufgetreten, bin mir aber nich sicher ob es tatsächlich geholfen hat oder einfach nur glücklich war, weil es eh nur sehr vereinzelt bei mir auftritt. Laut Doku sollte es mit 0 auch gepasst haben: " If `timeout == 0`, operations will run indefinitely. (Operating system timeouts may still apply).", vielleicht zwingt es mit 1 Minute aber auch tatsächlich das Betriebssystem den Request länger alive zu halten. Ich würde den Gonzo es erstmal einfach damit testen lassen.