### PR TITLE
Implemented V8 locker logger

### DIFF
--- a/src/main/cpp/bgjs/BGJSV8Engine.cpp
+++ b/src/main/cpp/bgjs/BGJSV8Engine.cpp
@@ -1374,8 +1374,21 @@ void BGJSV8Engine::unpause() {
     uv_mutex_unlock(&_uvMutex);
 }
 
+void BGJSV8Engine::SetCurrentThreadName(std::string name) {
+    JNIEnv* env = JNIWrapper::getEnvironment();
+
+    jclass threadClass = env->FindClass("java/lang/Thread");
+    jmethodID currentThreadMid = env->GetStaticMethodID(threadClass, "currentThread", "()Ljava/lang/Thread;");
+    jobject currentThread = env->CallStaticObjectMethod(threadClass, currentThreadMid);
+    jclass currentThreadClass = env->GetObjectClass(currentThread);
+    jmethodID setNameMid = env->GetMethodID(currentThreadClass, "setName", "(Ljava/lang/String;)V");
+    env->CallVoidMethod(currentThread, setNameMid, JNIWrapper::string2jstring(name));
+}
+
 void BGJSV8Engine::StartLoopThread(void *arg) {
     LOG(LOG_INFO, "BGJSV8Engine: EventLoop started");
+
+    SetCurrentThreadName("V8LoopThread");
 
     // the event loop retains the engine for as long as it is running
     JNIRetainedRef<BGJSV8Engine> engine = (BGJSV8Engine*)arg;

--- a/src/main/cpp/bgjs/BGJSV8Engine.cpp
+++ b/src/main/cpp/bgjs/BGJSV8Engine.cpp
@@ -955,7 +955,7 @@ void BGJSV8Engine::OnTimerEventCallback(uv_async_t * handle) {
     auto *engine = (BGJSV8Engine*)handle->data;
 
     v8::Isolate *isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
 
     for (size_t i = 0; i < engine->_timers.size(); ++i) {
         auto holder = engine->_timers.at(i);
@@ -979,7 +979,7 @@ void BGJSV8Engine::OnTimerTriggeredCallback(uv_timer_t * handle) {
     auto *holder = (TimerHolder*)handle->data;
 
     v8::Isolate *isolate = holder->engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = holder->engine->getContext();
@@ -1017,7 +1017,7 @@ void BGJSV8Engine::OnTimerClosedCallback(uv_handle_t * handle) {
 
     BGJSV8Engine *engine = holder->engine.get();
 
-    v8::Locker l(engine->getIsolate());
+    V8Locker l(engine->getIsolate(), __FUNCTION__);
 
     holder->callback.Reset();
     holder->engine.reset();
@@ -1153,7 +1153,7 @@ void BGJSV8Engine::createContext() {
     _isolate = v8::Isolate::New(create_params);
     _isolate->SetMicrotasksPolicy(v8::MicrotasksPolicy::kScoped);
 
-    v8::Locker l(_isolate);
+    V8Locker l(_isolate, __FUNCTION__);
     Isolate::Scope isolate_scope(_isolate);
     HandleScope scope(_isolate);
 
@@ -1467,7 +1467,7 @@ void BGJSV8Engine::OnHandleClosed(uv_handle_t *handle) {
 void BGJSV8Engine::OnTaskMicrotask(void *data) {
     TaskHolder *holder = (TaskHolder*)data;
     v8::Isolate *isolate = Isolate::GetCurrent();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     BGJSV8Engine* engine = BGJSV8Engine::GetInstance(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();
@@ -1487,7 +1487,7 @@ void BGJSV8Engine::OnTaskMicrotask(void *data) {
 
 void BGJSV8Engine::OnPromiseRejectionMicrotask(void *data) {
     v8::Isolate *isolate = Isolate::GetCurrent();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     BGJSV8Engine* engine = BGJSV8Engine::GetInstance(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();
@@ -1575,13 +1575,13 @@ void BGJSV8Engine::PromiseRejectionHandler(v8::PromiseRejectMessage message) {
 
 void BGJSV8Engine::UncaughtExceptionHandler(v8::Local<v8::Message> message, v8::Local<v8::Value> data) {
     v8::Isolate *isolate = Isolate::GetCurrent();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     BGJSV8Engine* engine = BGJSV8Engine::GetInstance(isolate);
     engine->forwardV8ExceptionToJNI("Uncaught exception: ", data, message, true);
 }
 
 void BGJSV8Engine::log(int debugLevel, const v8::FunctionCallbackInfo<v8::Value> &args) {
-    v8::Locker locker(args.GetIsolate());
+    V8Locker locker(args.GetIsolate(), __FUNCTION__);
     HandleScope scope(args.GetIsolate());
 
     std::stringstream str;
@@ -1650,7 +1650,7 @@ BGJSV8Engine::~BGJSV8Engine() {
 }
 
 void BGJSV8Engine::trace(const FunctionCallbackInfo<Value> &args) {
-    v8::Locker locker(args.GetIsolate());
+    V8Locker locker(args.GetIsolate(), __FUNCTION__);
     HandleScope scope(args.GetIsolate());
 
     std::stringstream str;
@@ -1685,7 +1685,7 @@ void BGJSV8Engine::doAssert(const FunctionCallbackInfo<Value> &args) {
         return;
     }
 
-    v8::Locker locker(isolate);
+    V8Locker locker(isolate, __FUNCTION__);
     HandleScope scope(isolate);
 
     Local<Boolean> assertion = args[0]->ToBoolean(isolate);
@@ -1776,7 +1776,7 @@ void BGJSV8Engine::OnGCCompletedForDump(Isolate *isolate, GCType type,
 
 const char *BGJSV8Engine::enqueueMemoryDump(const char *basePath) {
     v8::Isolate *isolate = getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
 
     if (_nextProfileDumpPath != nullptr) {
         return nullptr;
@@ -1847,7 +1847,7 @@ void BGJSV8Engine::jniEnqueueOnNextTick(JNIEnv *env, jobject obj, jobject functi
     THROW_IF_NOT_STARTED();
 
     v8::Isolate *isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();
@@ -1866,7 +1866,7 @@ jobject BGJSV8Engine::jniParseJSON(JNIEnv *env, jobject obj, jstring json) {
     THROW_IF_NOT_STARTED();
 
     v8::Isolate *isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();
@@ -1888,7 +1888,7 @@ jobject BGJSV8Engine::jniRequire(JNIEnv *env, jobject obj, jstring file) {
     THROW_IF_NOT_STARTED();
 
     v8::Isolate *isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();
@@ -1910,7 +1910,7 @@ jlong BGJSV8Engine::jniLock(JNIEnv *env, jobject obj) {
     THROW_IF_NOT_STARTED();
 
     v8::Isolate *isolate = engine->getIsolate();
-    auto *locker = new Locker(isolate);
+    auto *locker = new V8Locker(isolate, __FUNCTION__);
 
     return (jlong) locker;
 }
@@ -1920,7 +1920,7 @@ jobject BGJSV8Engine::jniGetGlobalObject(JNIEnv *env, jobject obj) {
     THROW_IF_NOT_STARTED();
 
     v8::Isolate *isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();
@@ -1931,7 +1931,7 @@ jobject BGJSV8Engine::jniGetGlobalObject(JNIEnv *env, jobject obj) {
 }
 
 void BGJSV8Engine::jniUnlock(JNIEnv *env, jobject obj, jlong lockerPtr) {
-    auto *locker = reinterpret_cast<Locker *>(lockerPtr);
+    auto *locker = reinterpret_cast<V8Locker *>(lockerPtr);
     delete (locker);
 }
 
@@ -1940,7 +1940,7 @@ jobject BGJSV8Engine::jniRunScript(JNIEnv *env, jobject obj, jstring script, jst
     THROW_IF_NOT_STARTED();
 
     v8::Isolate *isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();
@@ -1976,7 +1976,7 @@ jobject BGJSV8Engine::jniGetConstructor(JNIEnv *env, jobject obj, jstring canoni
     THROW_IF_NOT_STARTED();
 
     v8::Isolate *isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = engine->getContext();

--- a/src/main/cpp/bgjs/BGJSV8Engine.h
+++ b/src/main/cpp/bgjs/BGJSV8Engine.h
@@ -139,6 +139,7 @@ private:
     static void OnPromiseRejectionMicrotask(void* data);
     static void OnTaskMicrotask(void *data);
 
+	static void SetCurrentThreadName(std::string name);
     static void StartLoopThread(void *arg);
 	static void StopLoopThread(uv_async_t *handle);
 	static void SuspendLoopThread(uv_async_t *handle);

--- a/src/main/cpp/bgjs/BGJSV8Engine.h
+++ b/src/main/cpp/bgjs/BGJSV8Engine.h
@@ -160,7 +160,7 @@ private:
     static void jniEnqueueOnNextTick(JNIEnv *env, jobject obj, jobject function);
     static jobject jniParseJSON(JNIEnv *env, jobject obj, jstring json);
     static jobject jniRequire(JNIEnv *env, jobject obj, jstring file);
-    static jlong jniLock(JNIEnv *env, jobject obj);
+    static jlong jniLock(JNIEnv *env, jobject obj, jstring ownerName);
     static jobject jniGetGlobalObject(JNIEnv *env, jobject obj);
     static void jniUnlock(JNIEnv *env, jobject obj, jlong lockerPtr);
     static jobject jniRunScript(JNIEnv *env, jobject obj, jstring script, jstring name);

--- a/src/main/cpp/bgjs/modules/BGJSGLModule.cpp
+++ b/src/main/cpp/bgjs/modules/BGJSGLModule.cpp
@@ -67,7 +67,7 @@ CONTEXT_FETCH_BASE
 
 // Fetch the canvascontext from the context2d function for Accessors
 #define CONTEXT_FETCH_VAR               v8::Isolate* isolate = Isolate::GetCurrent(); \
-v8::Locker l(isolate); \
+V8Locker l(isolate, __FUNCTION__); \
 HandleScope scope(isolate); \
 Local<Object> self = info.Holder(); \
 Local<External> wrap = Local<External>::Cast(self->GetInternalField(0)); \
@@ -75,7 +75,7 @@ void* ptr = wrap->Value(); \
 BGJSCanvasContext *__context = static_cast<BGJSV8Engine2dGL*>(ptr)->context;
 
 #define CONTEXT_FETCH_VAR_ESCAPABLE       v8::Isolate* isolate = Isolate::GetCurrent(); \
-v8::Locker l(isolate); \
+V8Locker l(isolate, __FUNCTION__); \
 EscapableHandleScope scope(isolate); \
 Local<Object> self = info.Holder(); \
 Local<External> wrap = Local<External>::Cast(self->GetInternalField(0)); \

--- a/src/main/cpp/v8/JNIV8Array.cpp
+++ b/src/main/cpp/v8/JNIV8Array.cpp
@@ -167,7 +167,7 @@ jobject JNIV8Array::jniCreateWithLength(JNIEnv *env, jobject obj, jobject engine
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
@@ -182,7 +182,7 @@ jobject JNIV8Array::jniCreateWithArray(JNIEnv *env, jobject obj, jobject engineO
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);

--- a/src/main/cpp/v8/JNIV8Function.cpp
+++ b/src/main/cpp/v8/JNIV8Function.cpp
@@ -92,7 +92,7 @@ jobject JNIV8Function::jniCallAsV8Function(JNIEnv *env, jobject obj, jboolean as
     JNIV8JavaValue arg = JNIV8Marshalling::valueWithClass(type, returnType, (JNIV8MarshallingFlags)flags);
 
     v8::Isolate* isolate = ptr->getEngine()->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
     v8::Local<v8::Context> context = ptr->getEngine()->getContext();
@@ -242,7 +242,7 @@ jobject JNIV8Function::jniCreate(JNIEnv *env, jobject obj, jobject engineObj, jo
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);

--- a/src/main/cpp/v8/JNIV8Function.h
+++ b/src/main/cpp/v8/JNIV8Function.h
@@ -15,7 +15,7 @@ public:
     static void initializeJNIBindings(JNIClassInfo *info, bool isReload);
 
     static jobject jniCreate(JNIEnv *env, jobject obj, jobject engineObj, jobject handler);
-    static jobject jniCallAsV8Function(JNIEnv *env, jobject obj, jboolean asConstructor, jint flags, jint type, jclass returnType, jobject receiver, jobjectArray arguments);
+    static jobject jniCallAsV8Function(JNIEnv *env, jobject obj, jboolean asConstructor, jint flags, jint type, jclass returnType, jobject receiver, jstring callContext, jobjectArray arguments);
 
     /**
      * cache JNI class references

--- a/src/main/cpp/v8/JNIV8GenericObject.cpp
+++ b/src/main/cpp/v8/JNIV8GenericObject.cpp
@@ -19,7 +19,7 @@ jobject JNIV8GenericObject::jniCreate(JNIEnv *env, jobject obj, jobject engineOb
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);

--- a/src/main/cpp/v8/JNIV8Object.cpp
+++ b/src/main/cpp/v8/JNIV8Object.cpp
@@ -59,7 +59,7 @@ JNIV8Object::JNIV8Object(jobject obj, JNIClassInfo *info) : JNIObject(obj, info)
 }
 
 JNIV8Object::~JNIV8Object() {
-    v8::Locker l(_bgjsEngine->getIsolate());
+    V8Locker l(_bgjsEngine->getIsolate(), __FUNCTION__);
     // __android_log_print(ANDROID_LOG_INFO, "JNIV8Object", "deleted v8 object: %s", getCanonicalName().c_str());
     if(!_jsObject.IsEmpty()) {
         // adjust external memory counter if required
@@ -209,7 +209,7 @@ jobject JNIV8Object::jniCreate(JNIEnv *env, jobject obj, jobject engineObj, jstr
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);

--- a/src/main/cpp/v8/JNIV8Object.h
+++ b/src/main/cpp/v8/JNIV8Object.h
@@ -17,7 +17,7 @@ auto ptr = JNIWrapper::wrapObject<T>(obj);\
 if(!ptr){env->ThrowNew(env->FindClass("java/lang/RuntimeException"), "Attempt to call method on disposed object"); return R;}\
 BGJSV8Engine *engine = ptr->getEngine();\
 v8::Isolate* isolate = engine->getIsolate();\
-v8::Locker l(isolate);\
+V8Locker l(isolate, __FUNCTION__);\
 v8::Isolate::Scope isolateScope(isolate);\
 v8::HandleScope scope(isolate);\
 v8::Local<v8::Context> context = engine->getContext();\

--- a/src/main/cpp/v8/JNIV8Promise.cpp
+++ b/src/main/cpp/v8/JNIV8Promise.cpp
@@ -27,7 +27,7 @@ jobject JNIV8Promise::jniCreateResolver(JNIEnv *env, jobject obj, jobject engine
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);

--- a/src/main/cpp/v8/JNIV8Symbol.cpp
+++ b/src/main/cpp/v8/JNIV8Symbol.cpp
@@ -28,7 +28,7 @@ jobject JNIV8Symbol::jniCreate(JNIEnv *env, jobject obj, jobject engineObj, jstr
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
@@ -44,7 +44,7 @@ jobject JNIV8Symbol::jniFor(JNIEnv *env, jobject obj, jobject engineObj, jstring
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);
@@ -60,7 +60,7 @@ jobject JNIV8Symbol::jniForEnum(JNIEnv *env, jobject obj, jobject engineObj, jst
     auto engine = JNIWrapper::wrapObject<BGJSV8Engine>(engineObj);
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     v8::Isolate::Scope isolateScope(isolate);
     v8::HandleScope scope(isolate);

--- a/src/main/cpp/v8/JNIV8Wrapper.cpp
+++ b/src/main/cpp/v8/JNIV8Wrapper.cpp
@@ -299,7 +299,7 @@ void JNIV8Wrapper::initializeNativeJNIV8Object(jobject obj, jobject engineObj, j
     JNI_ASSERT(v8Object, "Invalid object; object must extend JNIV8Object and be registered on JNIV8Wrapper");
 
     v8::Isolate* isolate = engine->getIsolate();
-    v8::Locker l(isolate);
+    V8Locker l(isolate, __FUNCTION__);
     v8::MicrotasksScope taskScope(isolate, v8::MicrotasksScope::kRunMicrotasks);
     Isolate::Scope isolateScope(isolate);
     HandleScope scope(isolate);

--- a/src/main/java/ag/boersego/bgjs/BGJSGLView.kt
+++ b/src/main/java/ag/boersego/bgjs/BGJSGLView.kt
@@ -123,7 +123,7 @@ open class BGJSGLView(engine: V8Engine, private var textureView: V8TextureView?)
 
         // Clone and empty both lists of callbacks in a v8::Locker so JS cannot add event listeners
         // while we execute them
-        v8Engine.runLocked {
+        v8Engine.runLocked ("BGJSGLView::onRedraw") {
             val callbacksForRedraw = ArrayList<JNIV8Function>(queuedAnimationRequests.size)
             queuedAnimationRequests.forEach { callbacksForRedraw.add(it.cb) }
             queuedAnimationRequests.clear()

--- a/src/main/java/ag/boersego/bgjs/JNIV8Function.java
+++ b/src/main/java/ag/boersego/bgjs/JNIV8Function.java
@@ -20,81 +20,89 @@ final public class JNIV8Function extends JNIV8Object {
 
     public @Nullable
     Object callAsV8Function(@Nullable Object... arguments) {
-        return _callAsV8Function(false, 0, 0, Object.class, null, arguments);
+        String callContext = "callAsV8Function";
+
+        /*
+        // enable for debugging locks (disabled by default for performance reasons):
+        StackTraceElement element = Thread.currentThread().getStackTrace()[3];
+        callContext += "/" + element.getClassName() + "::" + element.getMethodName();
+        */
+
+        return _callAsV8Function(false, 0, 0, Object.class, null, callContext, arguments);
     }
 
     public @Nullable
     Object applyAsV8Function(@NonNull Object[] arguments) {
-        return _callAsV8Function(false, 0, 0, Object.class, null, arguments);
+        return _callAsV8Function(false, 0, 0, Object.class, null, "applyAsV8Function", arguments);
     }
 
     public @Nullable
     Object callAsV8FunctionWithReceiver(@NonNull Object receiver, @Nullable Object... arguments) {
-        return _callAsV8Function(false, 0, 0, Object.class, receiver, arguments);
+        return _callAsV8Function(false, 0, 0, Object.class, receiver, "callAsV8FunctionWithReceiver", arguments);
     }
 
     public @Nullable
     Object applyAsV8FunctionWithReceiver(@NonNull Object receiver, @NonNull Object[] arguments) {
-        return _callAsV8Function(false, 0, 0, Object.class, receiver, arguments);
+        return _callAsV8Function(false, 0, 0, Object.class, receiver, "applyAsV8FunctionWithReceiver", arguments);
     }
 
     public @NonNull
     Object callAsV8Constructor(@Nullable Object... arguments) {
-        return _callAsV8Function(true, V8Flags.NonNull, 0, Object.class, null, arguments);
+        return _callAsV8Function(true, V8Flags.NonNull, 0, Object.class, null, "callAsV8Constructor", arguments);
     }
 
     public @NonNull
     Object applyAsV8Constructor(@Nullable Object[] arguments) {
-        return _callAsV8Function(true, V8Flags.NonNull, 0, Object.class, null, arguments);
+        return _callAsV8Function(true, V8Flags.NonNull, 0, Object.class, null, "applyAsV8Constructor", arguments);
     }
 
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T callAsV8FunctionTyped(int flags, @NonNull Class<T> returnType, @Nullable Object... arguments) {
-        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, null, arguments);
+        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, null, "callAsV8FunctionTyped", arguments);
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T callAsV8FunctionTyped(@NonNull Class<T> returnType, @Nullable Object... arguments) {
-        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, null, arguments);
+        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, null, "callAsV8FunctionTyped", arguments);
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T callAsV8FunctionWithReceiverTyped(int flags, @NonNull Class<T> returnType, @NonNull Object receiver, @Nullable Object... arguments) {
-        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, receiver, arguments);
+        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, receiver, "callAsV8FunctionWithReceiverTyped", arguments);
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T callAsV8FunctionWithReceiverTyped(@NonNull Class<T> returnType, @NonNull Object receiver, @Nullable Object... arguments) {
-        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, receiver, arguments);
+        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, receiver, "callAsV8FunctionWithReceiverTyped", arguments);
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T applyAsV8FunctionTyped(int flags, @NonNull Class<T> returnType, @NonNull Object[] arguments) {
-        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, null, arguments);
+        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, null, "applyAsV8FunctionTyped", arguments);
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T applyAsV8FunctionTyped(@NonNull Class<T> returnType, @NonNull Object[] arguments) {
-        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, null, arguments);
+        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, null, "applyAsV8FunctionTyped", arguments);
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T applyAsV8FunctionWithReceiverTyped(int flags, @NonNull Class<T> returnType, @NonNull Object receiver, @NonNull Object[] arguments) {
-        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, receiver, arguments);
+        return (T) _callAsV8Function(false, flags, returnType.hashCode(), returnType, receiver, "applyAsV8FunctionWithReceiverTyped", arguments);
     }
 
     @SuppressWarnings("unchecked")
     public @Nullable
     <T> T applyAsV8FunctionWithReceiverTyped(@NonNull Class<T> returnType, @NonNull Object receiver, @NonNull Object[] arguments) {
-        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, receiver, arguments);
+        return (T) _callAsV8Function(false, V8Flags.Default, returnType.hashCode(), returnType, receiver, "applyAsV8FunctionWithReceiverTyped", arguments);
     }
 
     @Override
@@ -104,7 +112,7 @@ final public class JNIV8Function extends JNIV8Object {
 
     //------------------------------------------------------------------------
     // internal fields & methods
-    private native Object _callAsV8Function(boolean asConstructor, int flags, int type, Class returnType, Object receiver, Object... arguments);
+    private native Object _callAsV8Function(boolean asConstructor, int flags, int type, Class returnType, Object receiver, String callContext, Object... arguments);
 
     @Keep
     protected JNIV8Function(V8Engine engine, long jsObjPtr, Object[] arguments) {

--- a/src/main/java/ag/boersego/bgjs/V8TextureView.java
+++ b/src/main/java/ag/boersego/bgjs/V8TextureView.java
@@ -122,6 +122,7 @@ abstract public class V8TextureView extends TextureView implements TextureView.S
         mSurfaceWidth = width;
         mSurfaceHeight = height;
 
+        mRenderThread.setName("EjectaV8RenderThread");
         mRenderThread.start();
     }
 

--- a/src/main/java/ag/boersego/bgjs/modules/BGJSModuleAjaxRequest.kt
+++ b/src/main/java/ag/boersego/bgjs/modules/BGJSModuleAjaxRequest.kt
@@ -89,7 +89,7 @@ class BGJSModuleAjaxRequest(engine: V8Engine) : JNIV8Object(engine), Runnable {
     @V8Function
     fun abort(): Boolean {
         var success = false
-        v8Engine.runLocked {
+        v8Engine.runLocked ("BGJSModuleAjaxRequest::abort") {
             if (!requestNotFinal) {
                 if (DEBUG) {
                     Log.d(TAG, "ajax ${method} for ${url} cannot  abort", RuntimeException("ajax abort impossible"))
@@ -124,7 +124,7 @@ class BGJSModuleAjaxRequest(engine: V8Engine) : JNIV8Object(engine), Runnable {
                 if (aborted) {
                     return
                 }
-                v8Engine.runLocked {
+                v8Engine.runLocked ("BGJSModuleAjaxRequest::run") {
 
                     if (!aborted) {
                         val contentType = responseHeaders?.get("content-type")

--- a/src/main/java/ag/boersego/bgjs/modules/BGJSModuleWebSocket.kt
+++ b/src/main/java/ag/boersego/bgjs/modules/BGJSModuleWebSocket.kt
@@ -78,7 +78,7 @@ class BGJSWebSocket(engine: V8Engine) : JNIV8Object(engine), Runnable {
 
             override fun onMessage(webSocket: WebSocket, text: String) {
                 super.onMessage(webSocket, text)
-                v8Engine.runLocked {
+                v8Engine.runLocked ("BGJSWebSocket::onMessage") {
                     if (_readyState == ReadyState.CLOSING || _readyState == ReadyState.CLOSED) {
                         return@runLocked
                     }


### PR DESCRIPTION
For analyzing locks from v8::Locker, we implemented a wrapper class, that can be activated via V8_LOCK_LOGGING in BGJSV8Engine.h. Runtime-Overhead in C++ should be zero when not activated.

For more detailled JAVA-level context, V8Engine::runLocked accepts an optional parameter - additional stack info can be activated in V8Engine.java@runLocked (commented out by default).

More info from stack trace can be activated in JNIV8Function::callAsV8Function (commented out by default).

Runtime-Overhead on JAVA level should be very minimal when disabled (just passing an additional string to function)