### PR TITLE
Re-implemented jniEnqueueOnNextTick() just with libuv

### DIFF
--- a/src/main/cpp/bgjs/BGJSV8Engine.cpp
+++ b/src/main/cpp/bgjs/BGJSV8Engine.cpp
@@ -1184,8 +1184,6 @@ void BGJSV8Engine::createContext() {
                  v8::FunctionTemplate::New(_isolate, TraceCallback, Local<Value>(), Local<Signature>(), 0,
                                            ConstructorBehavior::kThrow));
 
-    globalObjTpl->Set(v8::String::NewFromUtf8(_isolate, "console").ToLocalChecked(), console);
-
     // Add methods to process function
     v8::Local<v8::FunctionTemplate> process = v8::FunctionTemplate::New(_isolate);
     process->Set(String::NewFromUtf8(_isolate, "nextTick").ToLocalChecked(),
@@ -1220,6 +1218,7 @@ void BGJSV8Engine::createContext() {
     // register global object for all required modules
     v8::Context::Scope ctxScope(context);
     context->Global()->Set(context, String::NewFromUtf8(_isolate, "global").ToLocalChecked(), context->Global());
+    context->Global()->Set(context, v8::String::NewFromUtf8(_isolate, "console").ToLocalChecked(), console->GetFunction(context).ToLocalChecked());
 
     _context.Reset(_isolate, context);
 

--- a/src/main/java/ag/boersego/bgjs/V8Engine.java
+++ b/src/main/java/ag/boersego/bgjs/V8Engine.java
@@ -32,7 +32,6 @@ public class V8Engine extends JNIObject {
 
     protected static V8Engine mInstance;
     private String mStoragePath;
-    protected Handler mHandler;
     private boolean mReady;
     private ArrayList<V8EngineHandler> mHandlers = null;
 
@@ -74,18 +73,11 @@ public class V8Engine extends JNIObject {
     }
 
     /**
-     * Enqueue a wrapped v8 function to be executed on the next tick
+     * Enqueue a callback to be executed in v8 loop thread on next tick
      *
-     * @param function the function to execute once the currently executing JS block has relinquished control
+     * @param runnable the callback to execute
      */
-    public native void enqueueOnNextTick(JNIV8Function function);
-
-    public void enqueueOnNextTick(Runnable runnable) {
-        this.enqueueOnNextTick(JNIV8Function.Create(this, (Object receiver, Object[] arguments) -> {
-            runnable.run();
-            return JNIV8Undefined.GetInstance();
-        }));
-    }
+    public native void enqueueOnNextTick(Runnable runnable);
 
     public interface V8EngineHandler {
         void onReady();


### PR DESCRIPTION
For avoiding locks, we optimized the possibility to execute JAVA-Callbacks on the v8 event loop thread to make it easy to replace runLocked() by enqueueOnNextTick()